### PR TITLE
Update redaxo/include/addons/phpmailer/lang/en_gb.lang

### DIFF
--- a/redaxo/include/addons/phpmailer/lang/en_gb.lang
+++ b/redaxo/include/addons/phpmailer/lang/en_gb.lang
@@ -1,23 +1,25 @@
+# addon:phpmailer en_gb
+
 phpmailer_title = PHPMailer
 phpmailer_configuration = Configuration
 phpmailer_example = Example
 phpmailer_example_headline = Example:
 phpmailer_config_settings = Settings
-phpmailer_sender_name = Sender (mame)
-phpmailer_sender_email = Sender (email)
-phpmailer_confirm = Confirmation (email)
-phpmailer_mailertype = Mailertype
+phpmailer_sender_name = Sender (name)
+phpmailer_sender_email = Sender (e-mail)
+phpmailer_confirm = Confirmation (e-mail)
+phpmailer_mailertype = Mailer type
 phpmailer_host = Host
 phpmailer_charset = Charset
 phpmailer_wordwrap = WordWrap
-phpmailer_encoding = Encodung
+phpmailer_encoding = Encoding
 phpmailer_priority = Priority
 phpmailer_save = Save
 phpmailer_reset = Reset
 phpmailer_reset_info = Reset info?
 phpmailer_Username = SMTP username
 phpmailer_Password = SMTP Password
-phpmailer_SMTPAuth = SMTP Authentification 
+phpmailer_SMTPAuth = SMTP Authentication 
 phpmailer_config_saved_error = Configuration could not be saved
 phpmailer_config_saved_successful = Configuration saved
 phpmailer_high = High


### PR DESCRIPTION
Tippfehler korrigiert
