### PR TITLE
Core/classes/rex list/extend custom columnformat params

### DIFF
--- a/redaxo/include/classes/class.rex_list.inc.php
+++ b/redaxo/include/classes/class.rex_list.inc.php
@@ -408,10 +408,11 @@ class rex_list
    * @param $columnName Name der Spalte
    * @param $format_type Formatierungstyp
    * @param $format Zu verwendentes Format
+   * @param $params Custom params für callback func bei format_type 'custom'
    */
-  function setColumnFormat($columnName, $format_type, $format = '')
+  function setColumnFormat($columnName, $format_type, $format = '', $params=array())
   {
-    $this->columnFormates[$columnName] = array($format_type, $format);
+    $this->columnFormates[$columnName] = array($format_type, $format, $params);
   }
 
   /**
@@ -932,7 +933,8 @@ class rex_list
       // Callbackfunktion -> Parameterliste aufbauen
       if($this->isCustomFormat($format))
       {
-        $format[1] = array($format[1], array('list' => $this, 'field' => $field, 'value' => $value, 'format' => $format[0], 'escape' => $escape));
+        $format[2] = isset($format[2]) ? $format[2] : array();
+        $format[1] = array($format[1], array('list' => $this, 'field' => $field, 'value' => $value, 'format' => $format[0], 'escape' => $escape, 'params'=>$format[2]));
       }
 
       $value = rex_formatter::format($value, $format[0], $format[1]);


### PR DESCRIPTION
extends the method setColumnFormat() with 4. param (array), which in case of format 'custom' will be merged into the callback's $params..

usage:

`$list->setColumnFormat('id', 'custom','my_callback','callback_params')`

result:

now in `my_callback($params) { ... }`

the array callback_params will be available in `$params['params']` ..
