### PR TITLE
Bugfix import/export-Addon

### DIFF
--- a/redaxo/include/addons/import_export/functions/function_import_export.inc.php
+++ b/redaxo/include/addons/import_export/functions/function_import_export.inc.php
@@ -328,19 +328,19 @@ function rex_a1_export_db($filename)
 
       $fields = $sql->getArray("SHOW FIELDS FROM `$table`");
 
-      foreach ($fields as $field)
+      foreach ($fields as $idx => $field)
       {
         if (preg_match('#^(bigint|int|smallint|mediumint|tinyint|timestamp)#i', $field['Type']))
         {
-          $field = 'int';
+          $fields[$idx] = 'int';
         }
         elseif (preg_match('#^(float|double|decimal)#', $field['Type']))
         {
-          $field = 'double';
+          $fields[$idx] = 'double';
         }
         elseif (preg_match('#^(char|varchar|text|longtext|mediumtext|tinytext)#', $field['Type']))
         {
-          $field = 'string';
+          $fields[$idx] = 'string';
         }
         // else ?
       }
@@ -384,6 +384,13 @@ function rex_a1_export_db($filename)
                 $record[] = sprintf('%.10F', (double) $column);
                 break;
               case 'string':
+                $recordwork = $sql->escape($column, "'");
+                if (substr($recordwork, 0, 1) <> "'")
+                {
+                  $recordwork = "'".$recordwork."'";
+                }
+                $record[] = $recordwork;
+                break;
               default:
                 $record[] = $sql->escape($column, "'");
                 break;


### PR DESCRIPTION
changes siehe https://github.com/aeberhard/redaxo4/commit/cd4abff7560c215804f29b7dfda6fe40386f6045

Beim export war der field-Type ($type) ein array und daher wurden alle feldtypen
beim switch über den default-zweig ausgegeben

string und default getrennt da sonst z.b. varchar-Felder mit Inhalt '1.' als numerisch
exportiert wurden, und daher beim import der '.' Punkt verschwindet!
