### PR TITLE
SQL-Abfragen in der Form "SELECT SQL_CALC_FOUND_ROWS viele-Spalten FROM ...

### DIFF
--- a/redaxo/include/classes/class.rex_list.inc.php
+++ b/redaxo/include/classes/class.rex_list.inc.php
@@ -713,8 +713,14 @@ class rex_list
     {
       $sql = rex_sql::factory();
       $sql->debugsql = $this->debug;
-      $sql->setQuery($this->query);
-      $this->rows = $sql->getRows();
+      if(strpos(strtoupper($this->query), ' SQL_CALC_FOUND_ROWS ') !== false)
+      {
+        $sql->setQuery('SELECT FOUND_ROWS()');
+        $this->rows = $sql->getValue('FOUND_ROWS()');
+      } else {
+        $sql->setQuery($this->query);
+        $this->rows = $sql->getRows();
+      }
     }
 
     return $this->rows;


### PR DESCRIPTION
...Tabellen LIMIT 0,30" liefern mit dieser kleinen Ergänzung ein deutlich schnelleres Ergebnis über die Gesamtanzahl der kompletten Abfrage ohne LIMIT als die bisherige Variante.

Das ist aber noch keine komplett fertige Lösung. Evtl. gibt es auch noch negative Korrelationen?
