### PR TITLE
Login Redirect Patch

### DIFF
--- a/redaxo/index.php
+++ b/redaxo/index.php
@@ -5,7 +5,6 @@
  * @package redaxo4
  * @version svn:$Id$
  */
-
 // ----- caching start für output filter
 ob_start();
 ob_implicit_flush(0);
@@ -281,8 +280,26 @@ if($REX['USER'])
       }
     }
 
-    header('Location: index.php?page='. $REX['PAGE']);
+    if(!$_SESSION['REDIRECT_REDAXO_AFTER_LOGIN']){
+      header('Location: index.php?page='. $REX['PAGE']);
+      
+    } else {
+      
+      if($_SESSION['REDIRECT_REDAXO_AFTER_LOGIN']) {
+        $redirect_to_url = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://').$_SERVER['HTTP_HOST'].$_SESSION['REDIRECT_REDAXO_AFTER_LOGIN'];
+        unset($_SESSION['REDIRECT_REDAXO_AFTER_LOGIN']);
+        header('Location:  ' . $redirect_to_url);
+      }
+    }
     exit();
+  }
+} else {
+  if(!$REX['USER'] && !isset($_SESSION['REDIRECT_REDAXO_AFTER_LOGIN'])){
+    if(!isset($_GET['rex_logout'])){
+      $_SESSION['REDIRECT_REDAXO_AFTER_LOGIN'] = strip_tags($_SERVER['REQUEST_URI']);
+    } else {
+      $_SESSION['REDIRECT_REDAXO_AFTER_LOGIN'] = false;
+    }
   }
 }
 


### PR DESCRIPTION
Ich habe die redaxo/index.php gepatched, damit man nach einem
Session-Timeout beim Re-Login nicht immer wieder auf der Startseite
landet, sondern auf die zuletzt besuchte Seite, bzw. die Seite, die man
eigentlich aufrufen wollte. Funktioniert mit jeder Seite, egal ob
AddOn, Medienpool oder Redaxo-Page.
