### PR TITLE
Stau vor ADDONS_INCLUDED: Konzept für Linderung..

### DIFF
--- a/redaxo/include/functions/function_rex_extension.inc.php
+++ b/redaxo/include/functions/function_rex_extension.inc.php
@@ -74,18 +74,12 @@ function rex_register_extension_point($extensionPoint, $subject = '', $params = 
  *
  * @param $extension Name des ExtensionPoints
  * @param $function Name der Callback-Funktion
- * @param $level Ausführungslevel (REX_EXTENSION_EARLY, REX_EXTENSION_NORMAL oder REX_EXTENSION_LATE)
  * @param $params Array von zusätzlichen Parametern
+ * @param $level Ausführungslevel (REX_EXTENSION_EARLY, REX_EXTENSION_NORMAL oder REX_EXTENSION_LATE)
  */
-function rex_register_extension($extensionPoint, $callable, $level = REX_EXTENSION_NORMAL, $params = array())
+function rex_register_extension($extensionPoint, $callable, $params = array(), $level = REX_EXTENSION_NORMAL)
 {
   global $REX;
-
-  // compat
-  if (is_array($level)) {
-    $params = $level;
-    $level = REX_EXTENSION_NORMAL;
-  }
 
   if(!is_array($params)) $params = array();
   $REX['EXTENSIONS'][$extensionPoint][(int) $level][] = array($callable, $params);


### PR DESCRIPTION
Nachdem ich letztens länger mit Markus Lorch darüber gesprochen habe - konkret aktuelles Rexseo bzw. aktuelle COM - folgende Überlegung wie man das Thema **wg. EP Timing muß ich nach hinten -> ADDON_INCLUDED** entschärfen könnte:

In der `addons.inc.php` werden für jedes Addon automatische Trigger-EPs erzeugt:
1. `"ADDONNAME"_PLUGINS_INCLUDED` (primär fürs Addon selbst gedacht zwecks Plugin EP Timing)
2. `"ADDONNAME"_INCLUDED` (für andere Addons gedacht im Sinne von Addon xyz hat einen Kram komplett erledigt)

Damit können Addon untereinander, bzw. ein Addon sich selbst gezielter in den include flow positionieren, und eben nicht mehr stumpf die `ADDON_INCLUDED` Keule nehmen.
Konkret z.b. müßte das aktuelle Rexseo dann eben nicht bis `ADDONS_INCLUDED` warten, sondern nur noch bis seine eigenen Plugins included sind , sprich -> `REXSEO_PLUGINS_INCLUDED`. Im selben Atmenzug könnten Addons sich auch wieder gezielter einhängen, im Falle der COM(AUTH) dann z.b. @ `REXSEO_INCLUDED`

Ohne es bisher live mal getestet zu haben denke ich man könnte auf dem Wege mit 2 Zeilen Code die Situation/Problematik ne ganze Ecke weit entspannen.. ohne sich (imho) Kompat probs einzufangen. Bezügl. "Resourcenhunger/scripttime": nach meinen Messungen bewegen sich leere EP aufrufe mit Microsekungen Bereich, sprich sind vernachläßigbar.

In code (`addons.inc.php`) ausgedrückt etwa so:

``` php
<?php

// ...

require $REX['INCLUDE_PATH']. '/plugins.inc.php';

foreach(OOAddon::getAvailableAddons() as $addonName)
{
  $addonConfig = rex_addons_folder($addonName). 'config.inc.php';
  if(file_exists($addonConfig))
  {
    require $addonConfig;
  }

  foreach(OOPlugin::getAvailablePlugins($addonName) as $pluginName)
  {
    $pluginConfig = rex_plugins_folder($addonName, $pluginName). 'config.inc.php';
    if(file_exists($pluginConfig))
    {
      rex_pluginManager::addon2plugin($addonName, $pluginName, $pluginConfig);
    }
  }
  rex_register_extension_point(strtoupper($addonName).'_PLUGINS_INCLUDED');
  rex_register_extension_point(strtoupper($addonName).'_INCLUDED');
}

// ----- all addons configs included
rex_register_extension_point('ADDONS_INCLUDED');
```

Meinungen?
