### PR TITLE
dritten Parameter gibt es nicht

### DIFF
--- a/redaxo/include/classes/class.rex_list.inc.php
+++ b/redaxo/include/classes/class.rex_list.inc.php
@@ -472,7 +472,6 @@ class rex_list
    *
    * @param $columnName Name der Spalte
    * @param $option Name/Id der Option
-   * @param $default Defaultrückgabewert, falls die Option nicht gesetzt ist
    *
    * @return boolean
    */


### PR DESCRIPTION
Einen dritten Parameter in der Funktion hasColumnOption gibt es nicht.
