### PR TITLE
class attribute and rex_list::addTableAttribute()

### DIFF
--- a/redaxo/include/classes/class.rex_list.inc.php
+++ b/redaxo/include/classes/class.rex_list.inc.php
@@ -101,7 +101,6 @@ class rex_list
     $this->rows = 0;
     $this->params = array();
     $this->tableAttributes = array();
-    $this->addTableAttribute('class', 'rex-table');
     $this->noRowsMessage = $I18N->msg('list_no_rows');
 
     // --------- Form Attributes
@@ -1008,6 +1007,13 @@ class rex_list
     // Table vars
     $caption = $this->getCaption();
     $tableColumnGroups = $this->getTableColumnGroups();
+    // Check if class attribute exists
+    if(!isset($this->tableAttributes['class'])) {
+        $this->addTableAttribute('class', 'rex-table');
+    } elseif ($this->tableAttributes['class']=='') {
+        $this->addTableAttribute('class', 'rex-table');
+     }
+
 
     // Columns vars
     $columnFormates = array();


### PR DESCRIPTION
I moved the setting for the default table class to rex_list::rex_list(), because the definition in get() would override settings by $list->addTableAttribute("class","new css class").
