### PR TITLE
Bugbehebung maxdepth

### DIFF
--- a/redaxo/include/classes/class.rex_navigation.inc.php
+++ b/redaxo/include/classes/class.rex_navigation.inc.php
@@ -368,7 +368,7 @@ class rex_navigation
         if(($this->open ||
             $nav->getId() == $this->current_category_id ||
             in_array($nav->getId(),$this->path))
-           && ($this->max_depth > $depth || $this->max_depth < 0)) {
+           && ($this->max_depth >= $depth || $this->max_depth < 0)) {
           $l .= $this->_getNavigation($nav->getId(), $depth);
         }
         $depth--;


### PR DESCRIPTION
Keine Ahnung, warum das so lange niemandem aufgefallen ist, aber wenn man eine zweistufige Navigation haben möchte, muss man im Moment die Klasse mit einer _maxdepth_ von 3 initialisieren.
