### PR TITLE
fixed warning

### DIFF
--- a/redaxo/include/classes/variables/class.rex_var_media.inc.php
+++ b/redaxo/include/classes/variables/class.rex_var_media.inc.php
@@ -335,9 +335,12 @@ class rex_var_media extends rex_var
       $open_params .= '&amp;rex_file_category=' . $category;
     }
 
-    foreach($args as $aname => $avalue)
+    if(count($args) > 0)
     {
-      $open_params .= '&amp;args['. $aname .']='. urlencode($avalue);
+      foreach($args as $aname => $avalue)
+      {
+        $open_params .= '&amp;args['. $aname .']='. urlencode($avalue);
+      }
     }
 
     $wdgtClass = 'rex-widget-medialist';


### PR DESCRIPTION
fixed invalid argument supplied for foreach() in
…/redaxo/include/classes/variables/class.rex_var_media.inc.php on line
338

Der letzte Parameter muss nicht zwingend ein Array sein, deswegen
sollte hier abgefangen werden! Oder Irre ich mich?

Beispiel: mForm

```
  $strOptions =
```

rex_var_media::getMediaListButton($arrElement['var-id'],
$arrElement['value'], $arrElement['cat-id'], $arrElement['parameter']);

Parameter ist hier leer..
