### PR TITLE
Update class.rex_article.inc.php

### DIFF
--- a/redaxo/include/classes/class.rex_article.inc.php
+++ b/redaxo/include/classes/class.rex_article.inc.php
@@ -134,6 +134,13 @@ class rex_article extends rex_article_base
             // Inhalt ueber sql generierens
             $CONTENT = parent::getArticle($curctype);
         }
+        
+        // ----- EXTENSION POINT
+        $CONTENT = rex_register_extension_point('ART_CONTENT', $CONTENT,
+            array (
+               'article' => &$this,
+            )
+        );
 
         return $CONTENT;
     }


### PR DESCRIPTION
Adding an extension point ('ART_CONTENT') allows to edit the article content itself, not only the complete page (extension point OUTPUT_FILTER). Example usage for protected content: Logged-out visitor sees login-form. Logged-In visitor sees content.
