### PR TITLE
fix linkmap

### DIFF
--- a/redaxo/include/pages/linkmap.inc.php
+++ b/redaxo/include/pages/linkmap.inc.php
@@ -72,9 +72,31 @@ $func_body .= 'var linkid = link.replace("redaxo://","");
 
 $navi_path = '<ul id="rex-navi-path">';
 
+if ($category_id == 0)
+{
+    $isRoot = true;
+    $category = false;
+}
+elseif (is_object(OOArticle::getArticleById($category_id)))
+{
+    $article = OOArticle::getArticleById($category_id);
+    if ($article->getCategory())
+    {
+        $isRoot = false;
+        $category = $article->getCategory();
+    }
+    else
+    {
+        $isRoot = true;
+        $category = false;
+    }
+}
+else
+{
+    $isRoot = true;
+    $category = false;
+}
 
-$isRoot = $category_id === 0;
-$category = OOCategory::getCategoryById($category_id);
 $link = rex_linkmap_url(array('category_id' => 0), $GlobalParams);
 
 $navi_path .= '<li>' . $I18N->msg('path') . ' </li>';

--- a/redaxo/media/standard.js
+++ b/redaxo/media/standard.js
@@ -314,7 +314,7 @@ function openREXLinklist(id, param)
 
     for (ii = 0; ii < sourcelength; ii++) {
         if (source.options[ii].selected) {
-            param = '&action=link_details&file_name='+ source.options[ii].value;
+            param = '&category_id='+ source.options[ii].value;
             break;
         }
     }


### PR DESCRIPTION
Wenn man in einem Linklist Widget einen Eintrag/ Artikel markiert und auf den "Link auswählen" Button klickt, wird im Linkmap Popup die Homepage Kategorie (also keine Kategorie) geöffnet. Es sollte aber die Kategorie geöffnet werden, in der sich der markierte Artikel befindet. Anscheinend war das mal irgendwann so gedacht, ist dann aber unter die Räder gekommen.
