### PR TITLE
Hauptmenü > AddOn in AddOns

### DIFF
--- a/redaxo/include/lang/de_de.lang
+++ b/redaxo/include/lang/de_de.lang
@@ -498,7 +498,7 @@ setup_no_js_security_msg = Prüfen Sie, ob Dateien aus dem Ordner redaxo/include
 setup_create_db = Datenbank anlegen?
 
 # redaxo\include\pages\addon.inc.php
-addon = AddOn
+addon = AddOns
 addon_help = Hilfe für
 addon_no_help_file = Keine Hilfedatei gefunden
 addon_back = zurück


### PR DESCRIPTION
#501

Mal ganz blöd gefragt: Die anderen Einträge im Hauptmenü heißen ja auch nicht "Modul" und "Template", sondern sind im Plural, weil es sich um mehrere Module und Templates handelt. Müsste das bei Addons nicht auch so sein?

Laut Duden wäre "Add-on" eigentlich die richtige Schreibweise.
http://www.duden.de/rechtschreibung/Add_on
