### PR TITLE
Erlaubt Backslashs bei Eingaben beim Setup

### DIFF
--- a/redaxo/include/pages/setup.inc.php
+++ b/redaxo/include/pages/setup.inc.php
@@ -378,8 +378,8 @@ function rex_setup_dropREXtables()
         $redaxo_db_create          = rex_post('redaxo_db_create', 'boolean');
 
         // einfache anführungszeichen und dollarzeichen maskieren
-        $search = array("'", '$');
-        $destroy = array("\\'", '\\$');
+        $search = array("'", '$', '\\');
+        $destroy = array("\\'", '\\$', '\\\\\\');
 
         $replace = array(
             'search' => array(


### PR DESCRIPTION
Mit der Änderung kann man u. a. beim Datenbankpasswort Backslashes verwenden.