### PR TITLE
Konstruktor fixes für PHP7

### DIFF
--- a/redaxo/include/addons/be_dashboard/classes/cache/class.rex_cache_file.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/cache/class.rex_cache_file.inc.php
@@ -32,6 +32,16 @@ class rex_file_cache extends rex_cache
      *
      * @see rex_cache
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_file_cache()
+    /*public*/ function __construct($options = array())
+    {
+        $this->rex_file_cache($options);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_file_cache($options = array())
     {
         global $REX;

--- a/redaxo/include/addons/be_dashboard/classes/cache/class.rex_cache_function.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/cache/class.rex_cache_function.inc.php
@@ -22,6 +22,16 @@ class rex_function_cache
      *
      * @param sfCache $cache An sfCache object instance
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_function_cache()
+    /*public*/ function __construct(/*rex_cache_*/ $cache)
+    {
+        $this->rex_function_cache($cache);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_function_cache(/*rex_cache_*/ $cache)
     {
         $this->cache = $cache;

--- a/redaxo/include/addons/be_dashboard/classes/class.component.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/class.component.inc.php
@@ -19,6 +19,15 @@
     var $format;
     var $block;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_dashboard_component()
+    function __construct($id, $cache_options = array())
+    {
+        $this->rex_dashboard_component($id, $cache_options);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_dashboard_component($id, $cache_options = array())
     {
         if (!isset($cache_options['lifetime'])) {

--- a/redaxo/include/addons/be_dashboard/classes/class.component_base.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/class.component_base.inc.php
@@ -16,6 +16,15 @@
     var $config;
     var $funcCache;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_dashboard_component_base()
+    function __construct($id, $cache_options = array())
+    {
+        $this->rex_dashboard_component_base($id, $cache_options);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_dashboard_component_base($id, $cache_options = array())
     {
         $this->id = $id;

--- a/redaxo/include/addons/be_dashboard/classes/class.component_config.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/class.component_config.inc.php
@@ -16,6 +16,15 @@
     var $settings;
     var $settingsCache;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_dashboard_component_config()
+    /*public*/ function __construct($defaultSettings)
+    {
+        $this->rex_dashboard_component_config($defaultSettings);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_dashboard_component_config($defaultSettings)
     {
         static $counter = 0;

--- a/redaxo/include/addons/be_dashboard/classes/class.notification.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/class.notification.inc.php
@@ -14,6 +14,15 @@
 {
     var $message;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_dashboard_notification()
+    function __construct($id, $cache_options = array())
+    {
+        $this->rex_dashboard_notification($id, $cache_options);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_dashboard_notification($id, $cache_options = array())
     {
         if (!isset($cache_options['lifetime'])) {

--- a/redaxo/include/addons/be_dashboard/classes/class.notification_component.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/class.notification_component.inc.php
@@ -12,6 +12,15 @@
 
 /*abstract*/ class rex_notification_component extends rex_dashboard_component
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_notification_component()
+    function __construct()
+    {
+        $this->rex_notification_component();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_notification_component()
     {
         global $I18N;

--- a/redaxo/include/addons/be_dashboard/classes/class.rex_cache.inc.php
+++ b/redaxo/include/addons/be_dashboard/classes/class.rex_cache.inc.php
@@ -33,6 +33,16 @@ define('REX_CACHE_CLEAN_ALL', 2);
      *
      * * lifetime (optional): The default life time (default value: 86400)
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_cache()
+    function __construct($options = array())
+    {
+        $this->rex_cache($options);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/function rex_cache($options = array())
     {
         $this->options = array_merge(array(

--- a/redaxo/include/addons/be_dashboard/plugins/rss_reader/classes/class.dashboard.inc.php
+++ b/redaxo/include/addons/be_dashboard/plugins/rss_reader/classes/class.dashboard.inc.php
@@ -12,6 +12,15 @@
 
 class rex_rss_reader_component extends rex_dashboard_component
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_rss_reader_component()
+    function __construct()
+    {
+        $this->rex_rss_reader_component();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_rss_reader_component()
     {
         // default cache lifetime in seconds
@@ -48,6 +57,15 @@ class rex_rss_reader_component extends rex_dashboard_component
 
 class rex_rss_reader_component_config extends rex_dashboard_component_config
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_rss_reader_component_config()
+    function __construct()
+    {
+        $this->rex_rss_reader_component_config();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_rss_reader_component_config()
     {
         $defaultSettings = array(

--- a/redaxo/include/addons/be_dashboard/plugins/rss_reader/classes/class.rss_reader.inc.php
+++ b/redaxo/include/addons/be_dashboard/plugins/rss_reader/classes/class.rss_reader.inc.php
@@ -31,6 +31,15 @@ require_once dirname(__FILE__) . '/../vendor/simplepie.inc.php';
  */
 class rex_rssReader extends SimplePie
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_rssReader()
+    function __construct($feed_url = null, $cache_location = null, $cache_duration = null)
+    {
+        $this->rex_rssReader($feed_url, $cache_location, $cache_duration);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_rssReader($feed_url = null, $cache_location = null, $cache_duration = null)
     {
         global $REX;

--- a/redaxo/include/addons/be_dashboard/plugins/userinfo/classes/class.dashboard.inc.php
+++ b/redaxo/include/addons/be_dashboard/plugins/userinfo/classes/class.dashboard.inc.php
@@ -17,6 +17,15 @@
 
 class rex_stats_component extends rex_dashboard_component
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_stats_component()
+    function __construct()
+    {
+        $this->rex_stats_component();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_stats_component()
     {
         global $I18N;
@@ -119,6 +128,15 @@ class rex_stats_component extends rex_dashboard_component
 
 class rex_articles_component extends rex_dashboard_component
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_articles_component()
+    function __construct()
+    {
+        $this->rex_articles_component();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_articles_component()
     {
         global $I18N;
@@ -176,6 +194,15 @@ class rex_articles_component extends rex_dashboard_component
 
 class rex_media_component extends rex_dashboard_component
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_media_component()
+    function __construct()
+    {
+        $this->rex_media_component();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_media_component()
     {
         global $I18N;

--- a/redaxo/include/addons/be_dashboard/plugins/version_checker/classes/class.dashboard.inc.php
+++ b/redaxo/include/addons/be_dashboard/plugins/version_checker/classes/class.dashboard.inc.php
@@ -12,6 +12,15 @@
 
 class rex_version_checker_notification extends rex_dashboard_notification
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_version_checker_notification()
+    function __construct()
+    {
+        $this->rex_version_checker_notification();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_version_checker_notification()
     {
         // default cache lifetime in seconds

--- a/redaxo/include/addons/cronjob/classes/class.form.inc.php
+++ b/redaxo/include/addons/cronjob/classes/class.form.inc.php
@@ -13,6 +13,15 @@ class rex_cronjob_form extends rex_form
 {
     /*private*/ var $mainFieldset;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_cronjob_form()
+    /*protected*/ function __construct($tableName, $fieldset, $whereCondition, $method = 'post', $debug = false)
+    {
+        $this->rex_cronjob_form($tableName, $fieldset, $whereCondition, $method, $debug);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*protected*/ function rex_cronjob_form($tableName, $fieldset, $whereCondition, $method = 'post', $debug = false)
     {
         parent::rex_form($tableName, $fieldset, $whereCondition, $method, $debug);

--- a/redaxo/include/addons/cronjob/classes/class.manager.inc.php
+++ b/redaxo/include/addons/cronjob/classes/class.manager.inc.php
@@ -138,6 +138,15 @@ class rex_cronjob_manager_sql
     /*private*/ var $sql;
     /*private*/ var $manager;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_cronjob_manager_sql()
+    /*private*/ function __construct(/*rex_cronjob_manager*/ $manager = null)
+    {
+        $this->rex_cronjob_manager_sql($manager);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*private*/ function rex_cronjob_manager_sql(/*rex_cronjob_manager*/ $manager = null)
     {
         $this->sql = rex_sql::factory();

--- a/redaxo/include/addons/image_manager/classes/class.rex_image.inc.php
+++ b/redaxo/include/addons/image_manager/classes/class.rex_image.inc.php
@@ -15,6 +15,15 @@ class rex_image
         'image/gif' => 'gif'
     );
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_image()
+    function __construct($filepath)
+    {
+        $this->rex_image($filepath);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_image($filepath)
     {
         global $REX;

--- a/redaxo/include/addons/image_manager/classes/class.rex_image_cacher.inc.php
+++ b/redaxo/include/addons/image_manager/classes/class.rex_image_cacher.inc.php
@@ -4,6 +4,15 @@ class rex_image_cacher
 {
     var $cache_path;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_image_cacher()
+    function __construct($cache_path)
+    {
+        $this->rex_image_cacher($cache_path);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_image_cacher($cache_path)
     {
         global $REX;

--- a/redaxo/include/addons/image_manager/classes/class.rex_image_manager.inc.php
+++ b/redaxo/include/addons/image_manager/classes/class.rex_image_manager.inc.php
@@ -4,6 +4,16 @@ class rex_image_manager
 {
     var $image_cacher;
 
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_image_manager()
+    function __construct(rex_image_cacher $image_cacher)
+    {
+        $this->rex_image_manager($image_cacher);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     public function rex_image_manager(rex_image_cacher $image_cacher)
     {
         if (!rex_image_cacher::isValid($image_cacher)) {

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_convert2img.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_convert2img.inc.php
@@ -14,6 +14,15 @@ class rex_effect_convert2img extends rex_effect_abstract
     private $tmp_imagepath = '';
 
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_convert2img()
+    function __construct()
+    { 
+        $this->rex_effect_convert2img();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_convert2img()
     {
 

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_crop.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_crop.inc.php
@@ -9,6 +9,15 @@
 class rex_effect_crop extends rex_effect_abstract
 {
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_crop()
+    function __construct()
+    {
+        $this->rex_effect_crop();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_crop()
     {
 

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_filter_blur.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_filter_blur.inc.php
@@ -5,6 +5,15 @@ class rex_effect_filter_blur extends rex_effect_abstract
 
     var $options;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_filter_blur()
+    function __construct()
+    {
+        $this->rex_effect_filter_blur();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_filter_blur()
     {
         $this->options = array(

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_flip.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_flip.inc.php
@@ -8,6 +8,15 @@ class rex_effect_flip extends rex_effect_abstract
 {
     var $options;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_flip()
+    function __construct()
+    {
+        $this->rex_effect_flip();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_flip()
     {
         $this->options = array(

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_mirror.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_mirror.inc.php
@@ -4,6 +4,15 @@ class rex_effect_mirror extends rex_effect_abstract
 {
     var $options;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_mirror()
+    function __construct()
+    {
+        $this->rex_effect_mirror();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_mirror()
     {
         $this->script = '

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_resize.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_resize.inc.php
@@ -9,6 +9,15 @@ class rex_effect_resize extends rex_effect_abstract
     var $options;
     var $script;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_resize()
+    function __construct()
+    {
+        $this->rex_effect_resize();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_resize()
     {
 

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_rounded_corners.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_rounded_corners.inc.php
@@ -9,6 +9,15 @@
 class rex_effect_rounded_corners extends rex_effect_abstract
 {
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_rounded_corners()
+    function __construct()
+    {
+        $this->rex_effect_rounded_corners();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_rounded_corners()
     {
 

--- a/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_workspace.inc.php
+++ b/redaxo/include/addons/image_manager/classes/effects/class.rex_effect_workspace.inc.php
@@ -12,6 +12,15 @@
 class rex_effect_workspace extends rex_effect_abstract
 {
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_effect_workspace()
+    function __construct()
+    {
+        $this->rex_effect_workspace();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_effect_workspace()
     {
         $this->options = array(

--- a/redaxo/include/addons/import_export/classes/class.rex_tar.inc.php
+++ b/redaxo/include/addons/import_export/classes/class.rex_tar.inc.php
@@ -16,6 +16,16 @@
 class rex_tar extends tar
 {
     // constructor to omit warnings
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_tar()
+    function __construct()
+    {
+        $this->rex_tar();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_tar()
     {
         parent::tar();

--- a/redaxo/include/addons/import_export/classes/class.tar.inc.php
+++ b/redaxo/include/addons/import_export/classes/class.tar.inc.php
@@ -77,6 +77,16 @@ class tar
 
 
     // Class Constructor -- Does nothing...
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of tar()
+    function __construct()
+    {
+        $this->tar();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function tar()
     {
         $this->files = array();

--- a/redaxo/include/addons/metainfo/classes/class.rex_input.inc.php
+++ b/redaxo/include/addons/metainfo/classes/class.rex_input.inc.php
@@ -5,6 +5,15 @@
     var $value;
     var $attributes;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input()
+    /*public*/ function __construct()
+    {
+        $this->rex_input();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_input()
     {
         $this->value = '';

--- a/redaxo/include/addons/metainfo/classes/class.rex_restrictions_element.php
+++ b/redaxo/include/addons/metainfo/classes/class.rex_restrictions_element.php
@@ -6,6 +6,16 @@ class rex_form_restrictons_element extends rex_form_select_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_restrictons_element()
+    function __construct($tag = '', /*rex_a62_tableExpander*/ &$table, $attributes = array())
+    {
+        $this->rex_form_restrictons_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_restrictons_element($tag = '', /*rex_a62_tableExpander*/ &$table, $attributes = array())
     {
         global $I18N;

--- a/redaxo/include/addons/metainfo/classes/class.rex_table_expander.inc.php
+++ b/redaxo/include/addons/metainfo/classes/class.rex_table_expander.inc.php
@@ -14,6 +14,15 @@ class rex_a62_tableExpander extends rex_form
     var $metaPrefix;
     var $tableManager;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_a62_tableExpander()
+    /*public*/ function __construct($metaPrefix, $metaTable, $tableName, $fieldset, $whereCondition, $method = 'post', $debug = false)
+    {
+        $this->rex_a62_tableExpander($metaPrefix, $metaTable, $tableName, $fieldset, $whereCondition, $method, $debug);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_a62_tableExpander($metaPrefix, $metaTable, $tableName, $fieldset, $whereCondition, $method = 'post', $debug = false)
     {
         $this->metaPrefix = $metaPrefix;

--- a/redaxo/include/addons/metainfo/classes/class.rex_table_manager.inc.php
+++ b/redaxo/include/addons/metainfo/classes/class.rex_table_manager.inc.php
@@ -14,6 +14,15 @@ class rex_a62_tableManager
     var $tableName;
     var $DBID;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_a62_tableManager()
+    function __construct($tableName, $DBID = 1)
+    {
+        $this->rex_a62_tableManager($tableName, $DBID);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_a62_tableManager($tableName, $DBID = 1)
     {
         $this->tableName = $tableName;

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_date.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_date.inc.php
@@ -6,6 +6,15 @@ class rex_input_date extends rex_input
     var $monthSelect;
     var $daySelect;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_date()
+    function __construct()
+	{
+        $this->rex_input_date();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_date()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_datetime.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_datetime.inc.php
@@ -5,6 +5,15 @@ class rex_input_datetime extends rex_input
     var $dateInput;
     var $timeInput;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_datetime()
+    function __construct()
+    {
+        $this->rex_input_datetime();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_datetime()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_linkbutton.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_linkbutton.inc.php
@@ -5,6 +5,15 @@ class rex_input_linkbutton extends rex_input
     var $buttonId;
     var $categoryId;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_linkbutton()
+    function __construct()
+    {
+        $this->rex_input_linkbutton();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_linkbutton()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_linklistbutton.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_linklistbutton.inc.php
@@ -5,6 +5,15 @@ class rex_input_linklistbutton extends rex_input
     var $buttonId;
     var $categoryId;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_linklistbutton()
+    function __construct()
+    {
+        $this->rex_input_linklistbutton();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_linklistbutton()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_mediabutton.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_mediabutton.inc.php
@@ -6,6 +6,15 @@ class rex_input_mediabutton extends rex_input
     var $categoryId;
     var $args = array();
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_mediabutton()
+    function __construct()
+    {
+        $this->rex_input_mediabutton();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_mediabutton()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_medialistbutton.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_medialistbutton.inc.php
@@ -6,6 +6,15 @@ class rex_input_medialistbutton extends rex_input
     var $categoryId;
     var $args = array();
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_medialistbutton()
+    function __construct()
+    {
+        $this->rex_input_medialistbutton();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_medialistbutton()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_select.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_select.inc.php
@@ -4,6 +4,15 @@ class rex_input_select extends rex_input
 {
     var $select;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_select()
+    function __construct()
+    { 
+        $this->rex_input_select();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_select()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_text.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_text.inc.php
@@ -2,6 +2,15 @@
 
 class rex_input_text extends rex_input
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_text()
+    function __construct()
+    {
+        $this->rex_input_text();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_text()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_textarea.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_textarea.inc.php
@@ -2,6 +2,15 @@
 
 class rex_input_textarea extends rex_input
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_textarea()
+    function __construct()
+    {
+        $this->rex_input_textarea();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_textarea()
     {
         parent::rex_input();

--- a/redaxo/include/addons/metainfo/classes/input/class.rex_input_time.inc.php
+++ b/redaxo/include/addons/metainfo/classes/input/class.rex_input_time.inc.php
@@ -5,6 +5,15 @@ class rex_input_time extends rex_input
     var $hourSelect;
     var $timeSelect;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_input_time()
+    function __construct()
+    {
+        $this->rex_input_time();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_input_time()
     {
         parent::rex_input();

--- a/redaxo/include/addons/phpmailer/classes/class.rex_mailer.inc.php
+++ b/redaxo/include/addons/phpmailer/classes/class.rex_mailer.inc.php
@@ -14,6 +14,15 @@ class rex_mailer extends PHPMailer
 {
     public $AdminBcc = '';
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_mailer()
+    function __construct()
+    {
+        $this->rex_mailer();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_mailer()
     {
         global $REX;

--- a/redaxo/include/classes/class.compat.inc.php
+++ b/redaxo/include/classes/class.compat.inc.php
@@ -14,6 +14,15 @@ class sql extends rex_sql
 {
     var $select;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of sql()
+    function __construct($DBID = 1)
+    {
+        $this->sql($DBID);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function sql($DBID = 1)
     {
         parent::rex_sql($DBID);
@@ -70,6 +79,15 @@ class sql extends rex_sql
 class select extends rex_select
 {
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of select()
+    function __construct()
+    {
+        $this->select();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function select()
     {
         parent::rex_select();
@@ -135,6 +153,15 @@ class select extends rex_select
 class article extends rex_article
 {
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of article()
+    function __construct($article_id = null, $clang = null)
+    {
+        $this->article($article_id, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function article($article_id = null, $clang = null)
     {
         parent::rex_article($article_id, $clang);

--- a/redaxo/include/classes/class.i18n.inc.php
+++ b/redaxo/include/classes/class.i18n.inc.php
@@ -15,12 +15,22 @@ class i18n
     var $text;
     var $text_loaded;
 
-    /*
+     /*
      * Constructor
      * the locale must of the common form, eg. de_de, en_us or just plain en, de.
      * the searchpath is where the language files are located
      */
-    function i18n($locale = 'de_de', $searchpath)
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of i18n()
+    function __construct($locale = 'de_de', $searchpath)
+    {
+        $this->i18n($locale, $searchpath);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
+    function i18n($locale = 'de_de', $searchpath) 
     {
         $this->searchpath = $searchpath;
         $this->text = array ();

--- a/redaxo/include/classes/class.ooarticle.inc.php
+++ b/redaxo/include/classes/class.ooarticle.inc.php
@@ -8,6 +8,15 @@
 
 class OOArticle extends OORedaxo
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of OOArticle()
+    /*protected*/ function __construct($params = false, $clang = false)
+    {
+        $this->OOArticle($params, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*protected*/ function OOArticle($params = false, $clang = false)
     {
         parent :: OORedaxo($params, $clang);

--- a/redaxo/include/classes/class.ooarticleslice.inc.php
+++ b/redaxo/include/classes/class.ooarticleslice.inc.php
@@ -40,6 +40,16 @@ class OOArticleSlice
     /*
      * Constructor
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of OOArticleSlice()
+    /*public*/ function __construct($id, $article_id, $clang, $ctype, $modultyp_id, $re_article_slice_id, $next_article_slice_id, $createdate, $updatedate, $createuser, $updateuser, $revision, $values, $files, $filelists, $links, $linklists, $php, $html)
+    {
+        $this->OOArticleSlice($id, $article_id, $clang, $ctype, $modultyp_id, $re_article_slice_id, $next_article_slice_id, $createdate, $updatedate, $createuser, $updateuser, $revision, $values, $files, $filelists, $links, $linklists, $php, $html);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function OOArticleSlice(
         $id, $article_id, $clang, $ctype, $modultyp_id,
         $re_article_slice_id, $next_article_slice_id,

--- a/redaxo/include/classes/class.oocategory.inc.php
+++ b/redaxo/include/classes/class.oocategory.inc.php
@@ -8,6 +8,16 @@
 
 class OOCategory extends OORedaxo
 {
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of OOCategory()
+    /*protected*/ function __construct($params = false, $clang = false)
+    {
+        $this->OOCategory($params, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*protected*/ function OOCategory($params = false, $clang = false)
     {
         parent :: OORedaxo($params, $clang);

--- a/redaxo/include/classes/class.oomedia.inc.php
+++ b/redaxo/include/classes/class.oomedia.inc.php
@@ -51,6 +51,16 @@ class OOMedia
     /**
      * @access protected
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of OOMedia()
+    function __construct($id = null)
+    {
+        $this->OOMedia($id);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function OOMedia($id = null)
     {
         $this->getMediaById($id);

--- a/redaxo/include/classes/class.oomediacategory.inc.php
+++ b/redaxo/include/classes/class.oomediacategory.inc.php
@@ -37,6 +37,16 @@ class OOMediaCategory
     /**
      * @access protected
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of OOMediaCategory()
+    function __construct($id = null)
+    {
+        $this->OOMediaCategory($id);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function OOMediaCategory($id = null)
     {
         $this->getCategoryById($id);

--- a/redaxo/include/classes/class.ooredaxo.inc.php
+++ b/redaxo/include/classes/class.ooredaxo.inc.php
@@ -32,6 +32,16 @@
     /*
      * Constructor
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of OORedaxo()
+    /*protected*/ function __construct($params = false, $clang = false)
+    {
+        $this->OORedaxo($params, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*protected*/ function OORedaxo($params = false, $clang = false)
     {
         if ($params !== false) {

--- a/redaxo/include/classes/class.rex_addon.inc.php
+++ b/redaxo/include/classes/class.rex_addon.inc.php
@@ -18,6 +18,16 @@
      *
      * @param string|array $namespace Namensraum des rex-Addons
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_addon()
+    /*private*/ function __construct($namespace)
+    {
+        $this->rex_addon($namespace);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*private*/ function rex_addon($namespace)
     {
         global $REX;

--- a/redaxo/include/classes/class.rex_article.inc.php
+++ b/redaxo/include/classes/class.rex_article.inc.php
@@ -13,6 +13,15 @@ class rex_article extends rex_article_base
     // bc schalter
     var $viasql;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_article()
+    /*public*/ function __construct($article_id = null, $clang = null)
+    {
+        $this->rex_article($article_id, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_article($article_id = null, $clang = null)
     {
         $this->viasql = false;

--- a/redaxo/include/classes/class.rex_article_base.inc.php
+++ b/redaxo/include/classes/class.rex_article_base.inc.php
@@ -32,6 +32,15 @@ class rex_article_base
     var $info;
     var $debug;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_article_base()
+    /*private*/ function __construct($article_id = null, $clang = null)
+    {
+        $this->rex_article_base($article_id, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*private*/ function rex_article_base($article_id = null, $clang = null)
     {
         global $REX;

--- a/redaxo/include/classes/class.rex_article_editor.inc.php
+++ b/redaxo/include/classes/class.rex_article_editor.inc.php
@@ -11,6 +11,15 @@ class rex_article_editor extends rex_article
 {
     var $MODULESELECT;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_article_editor()
+    /*public*/ function __construct($article_id = null, $clang = null)
+    {
+        $this->rex_article_editor($article_id, $clang);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_article_editor($article_id = null, $clang = null)
     {
         parent::rex_article($article_id, $clang);

--- a/redaxo/include/classes/class.rex_form.inc.php
+++ b/redaxo/include/classes/class.rex_form.inc.php
@@ -38,6 +38,16 @@ class rex_form
     /**
      * Diese Konstruktor sollte nicht verwendet werden. Instanzen muessen ueber die facotry() Methode erstellt werden!
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form()
+    /*protected*/ function __construct($tableName, $fieldset, $whereCondition, $method = 'post', $debug = false)
+    {
+        $this->rex_form($tableName, $fieldset, $whereCondition, $method, $debug);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*protected*/ function rex_form($tableName, $fieldset, $whereCondition, $method = 'post', $debug = false)
     {
         global $REX;
@@ -1284,6 +1294,16 @@ class rex_form_element
     /** @var rex_validator */
     protected $validator;
 
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_element()
+    function __construct($tag, &$table, $attributes = array(), $separateEnding = false)
+    {
+        $this->rex_form_element($tag, $table, $attributes, $separateEnding);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_element($tag, &$table, $attributes = array(), $separateEnding = false)
     {
         $this->value = null;
@@ -1562,6 +1582,15 @@ class rex_form_control_element extends rex_form_element
     var $resetElelement;
     var $abortElement;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_control_element()
+    function __construct(&$table, $saveElement = null, $applyElement = null, $deleteElement = null, $resetElement = null, $abortElement = null)
+    {
+        $this->rex_form_control_element($table, $saveElement, $applyElement, $deleteElement, $resetElement, $abortElement);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_control_element(&$table, $saveElement = null, $applyElement = null, $deleteElement = null, $resetElement = null, $abortElement = null)
     {
         parent::rex_form_element('', $table);
@@ -1687,6 +1716,16 @@ class rex_form_select_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_select_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_select_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_select_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element('', $table, $attributes);
@@ -1758,6 +1797,16 @@ class rex_form_prio_element extends rex_form_select_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_prio_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_prio_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_prio_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_select_element('', $table, $attributes);
@@ -1847,6 +1896,16 @@ class rex_form_options_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_options_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_options_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_options_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element($tag, $table, $attributes);
@@ -1909,6 +1968,16 @@ class rex_form_checkbox_element extends rex_form_options_element
 {
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_checkbox_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_checkbox_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_checkbox_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_options_element('', $table, $attributes);
@@ -1964,6 +2033,16 @@ class rex_form_radio_element extends rex_form_options_element
 {
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_radio_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_radio_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_radio_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_options_element('', $table, $attributes);
@@ -2010,6 +2089,16 @@ class rex_form_element_container extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_element_container()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_element_container($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_element_container($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element('', $table, $attributes);
@@ -2140,6 +2229,16 @@ class rex_form_widget_media_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_widget_media_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_widget_media_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_widget_media_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element('', $table, $attributes);
@@ -2181,6 +2280,16 @@ class rex_form_widget_medialist_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_widget_medialist_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_widget_medialist_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_widget_medialist_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element('', $table, $attributes);
@@ -2220,6 +2329,16 @@ class rex_form_widget_linkmap_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_widget_linkmap_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_widget_linkmap_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_widget_linkmap_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element('', $table, $attributes);
@@ -2248,6 +2367,16 @@ class rex_form_widget_linklist_element extends rex_form_element
 
     // 1. Parameter nicht genutzt, muss aber hier stehen,
     // wg einheitlicher Konstrukturparameter
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_widget_linklist_element()
+    function __construct($tag = '', &$table, $attributes = array())
+    {
+        $this->rex_form_widget_linklist_element($tag, $table, $attributes);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_widget_linklist_element($tag = '', &$table, $attributes = array())
     {
         parent::rex_form_element('', $table, $attributes);
@@ -2277,6 +2406,15 @@ class rex_form_raw_element extends rex_form_element
 {
     var $html;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_form_raw_element()
+    function __construct($html = '')
+    {
+        $this->rex_form_raw_element($html);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_form_raw_element($html = '')
     {
         $this->html = $html;

--- a/redaxo/include/classes/class.rex_list.inc.php
+++ b/redaxo/include/classes/class.rex_list.inc.php
@@ -85,6 +85,16 @@ class rex_list
      * @param $rowsPerPage Anzahl der Elemente pro Zeile
      * @param $listName Name der Liste
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_list()
+    function __construct($query, $rowsPerPage = 30, $listName = null, $debug = false)
+    {
+        $this->rex_list($query, $rowsPerPage, $listName, $debug);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_list($query, $rowsPerPage = 30, $listName = null, $debug = false)
     {
         global $REX, $I18N;

--- a/redaxo/include/classes/class.rex_login.inc.php
+++ b/redaxo/include/classes/class.rex_login.inc.php
@@ -10,6 +10,15 @@
 
 class rex_login_sql extends rex_sql
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_login_sql()
+    function __construct($DBID = 1)
+    {
+        $this->rex_login_sql($DBID);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_login_sql($DBID = 1)
     {
         parent::rex_sql($DBID);
@@ -193,6 +202,15 @@ class rex_login
     var $cache;
     var $login_status;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_login()
+    /*public*/ function __construct()
+    {
+        $this->rex_login();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_login()
     {
         $this->DB = 1;
@@ -488,6 +506,15 @@ class rex_backend_login extends rex_login
 {
     var $tableName;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_backend_login()
+    /*public*/ function __construct($tableName)
+    {
+        $this->rex_backend_login($tableName);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_backend_login($tableName)
     {
         global $REX;

--- a/redaxo/include/classes/class.rex_manager.inc.php
+++ b/redaxo/include/classes/class.rex_manager.inc.php
@@ -12,6 +12,16 @@
      *
      * @param $i18nPrefix Sprachprefix aller I18N Sprachschlüssel
      */
+
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_baseManager()
+    function __construct($i18nPrefix)
+    {
+        $this->rex_baseManager($i18nPrefix);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_baseManager($i18nPrefix)
     {
         $this->i18nPrefix = $i18nPrefix;
@@ -326,6 +336,15 @@ class rex_addonManager extends rex_baseManager
 {
     var $configArray;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_addonManager()
+    function __construct($configArray)
+    {
+        $this->rex_addonManager($configArray);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_addonManager($configArray)
     {
         $this->configArray = $configArray;
@@ -397,6 +416,14 @@ class rex_pluginManager extends rex_baseManager
     var $configArray;
     var $addonName;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_pluginManager()
+    function __construct($configArray, $addonName)
+    {
+        $this->rex_pluginManager($configArray, $addonName);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
     function rex_pluginManager($configArray, $addonName)
     {
         $this->configArray = & $configArray;

--- a/redaxo/include/classes/class.rex_navigation.inc.php
+++ b/redaxo/include/classes/class.rex_navigation.inc.php
@@ -47,6 +47,15 @@ class rex_navigation
     var $current_article_id = -1; // Aktueller Artikel
     var $current_category_id = -1; // Aktuelle Katgorie
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_navigation()
+    /*private*/ function __construct()
+    {
+        $this->rex_navigation();
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*private*/ function rex_navigation()
     {
         // nichts zu tun
@@ -702,6 +711,15 @@ class rex_be_page extends rex_be_page_container
     var $requiredPermissions;
     var $path;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_be_page()
+    function __construct($title, $activateCondition = array(), $hidden = false)
+    {
+        $this->rex_be_page($title, $activateCondition, $hidden);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_be_page($title, $activateCondition = array(), $hidden = false)
     {
         $this->title = $title;
@@ -875,6 +893,15 @@ class rex_be_main_page extends rex_be_page_container
     var $block;
     var $page;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_be_main_page()
+    function __construct($block, /*rex_be_page*/ $page)
+    {
+        $this->rex_be_main_page($block, $page);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_be_main_page($block, /*rex_be_page*/ $page)
     {
         $this->block = $block;
@@ -926,6 +953,15 @@ class rex_be_main_page extends rex_be_page_container
 
 class rex_be_popup_page extends rex_be_page
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_be_popup_page()
+    function __construct($title, $onclick = '', $activateCondition = array())
+    {
+        $this->rex_be_popup_page($title, $onclick, $activateCondition);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_be_popup_page($title, $onclick = '', $activateCondition = array())
     {
         parent::rex_be_page($title, $activateCondition);

--- a/redaxo/include/classes/class.rex_select.inc.php
+++ b/redaxo/include/classes/class.rex_select.inc.php
@@ -17,6 +17,15 @@ class rex_select
     var $optgroups = array();
 
     ################ Konstruktor
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_select()
+    /*public*/ function __construct()
+    {
+        $this->rex_select();
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_select()
     {
         $this->init();
@@ -334,6 +343,15 @@ class rex_category_select extends rex_select
     /*private*/ var $rootId;
     /*private*/ var $loaded;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_category_select()
+    /*public*/ function __construct($ignore_offlines = false, $clang = false, $check_perms = true, $add_homepage = true)
+    {
+        $this->rex_category_select($ignore_offlines, $clang, $check_perms, $add_homepage);
+    }
+
+     // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_category_select($ignore_offlines = false, $clang = false, $check_perms = true, $add_homepage = true)
     {
         $this->ignore_offlines = $ignore_offlines;
@@ -471,6 +489,15 @@ class rex_mediacategory_select extends rex_select
     var $rootId;
     /*private*/ var $loaded;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_mediacategory_select()
+    /*public*/ function __construct($check_perms = true)
+    {
+        $this->rex_mediacategory_select($check_perms);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*public*/ function rex_mediacategory_select($check_perms = true)
     {
         $this->check_perms = $check_perms;

--- a/redaxo/include/classes/class.rex_sql.inc.php
+++ b/redaxo/include/classes/class.rex_sql.inc.php
@@ -24,6 +24,15 @@ class rex_sql
     var $error; // Fehlertext
     var $errno; // Fehlernummer
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_sql()
+    /*private*/ function __construct($DBID = 1)
+    {
+        $this->rex_sql($DBID);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     /*private*/ function rex_sql($DBID = 1)
     {
         global $REX;

--- a/redaxo/include/classes/class.rex_template.inc.php
+++ b/redaxo/include/classes/class.rex_template.inc.php
@@ -12,6 +12,15 @@ class rex_template
 {
     var $id;
 
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_template()
+    function __construct($template_id = 0)
+    {
+        $this->rex_template($template_id);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_template($template_id = 0)
     {
         $this->setId($template_id);

--- a/redaxo/include/pages/module.action.inc.php
+++ b/redaxo/include/pages/module.action.inc.php
@@ -14,6 +14,15 @@ $ASTATUS[2] = 'DELETE';
 
 class rex_event_select extends rex_select
 {
+    // this is the new style constructor used by newer php versions.
+    // important: if you change the signatur of this method, change also the signature of rex_event_select()
+    function __construct($options)
+    {
+        $this->rex_event_select($options);
+    }
+
+    // this is the deprecated old style constructor kept for compat reasons. 
+    // important: if you change the signatur of this method, change also the signature of __construct()
     function rex_event_select($options)
     {
         global $I18N;


### PR DESCRIPTION
refs #414 

Das sollte alle sein.
Mir ist noch aufgefallen dass beim PHP Mailer die Rechte nicht stimmen.

```
redaxo/include/addons/phpmailer/classes/class.phpmailer.php 100755
redaxo/include/addons/phpmailer/classes/class.pop3.php 100755
redaxo/include/addons/phpmailer/classes/class.smtp.php 100755
redaxo/include/addons/phpmailer/classes/language/phpmailer.lang-de.php 100755
```

Ich werde noch für xform und community das gleiche machen im Anschluß...