### PR TITLE
fix error with php 7.1

### DIFF
--- a/redaxo/include/classes/class.rex_login.inc.php
+++ b/redaxo/include/classes/class.rex_login.inc.php
@@ -493,6 +493,9 @@ class rex_login
      */
     /*public*/ function sessionFixation()
     {
+        if (session_status() == PHP_SESSION_NONE) {
+            session_start();
+        }
         // 1. parameter ist erst seit php5.1 verfügbar
         if (version_compare(phpversion(), '5.1.0', '>=') == 1) {
             session_regenerate_id(true);


### PR DESCRIPTION
session_regenerate_id(): Cannot regenerate session id - session is not active in ....
Dieser Fehler tritt nur auf, wenn man die login class "zweckentfremdet" und in Verbindung mit dem community_addon direkt nutzt (keine abwägige Methode). Vor PHP 7 komischerweise kein Problem. Mit dem kleinen Fix von mir wird das Problem behoben.