### PR TITLE
replace deprecated create_function for php 7.2 compatibility

### DIFF
--- a/redaxo/include/classes/class.rex_article_base.inc.php
+++ b/redaxo/include/classes/class.rex_article_base.inc.php
@@ -39,7 +39,7 @@ class rex_article_base
         $this->rex_article_base($article_id, $clang);
     }
 
-    // this is the deprecated old style constructor kept for compat reasons. 
+    // this is the deprecated old style constructor kept for compat reasons.
     // important: if you change the signatur of this method, change also the signature of __construct()
     /*private*/ function rex_article_base($article_id = null, $clang = null)
     {
@@ -522,10 +522,12 @@ class rex_article_base
     {
         return preg_replace_callback(
             '@redaxo://(\d+)(?:-(\d+))?/?@i',
-            create_function(
-                '$matches',
-                'return rex_getUrl($matches[1], isset($matches[2]) ? $matches[2] : ' . (integer) $this->clang . ');'
-            ),
+            function ($matches) {
+                $secondParam = isset($matches[2])
+                    ? $matches[2]
+                    : (integer) $this->clang;
+                return rex_getUrl($matches[1], $secondParam );
+            },
             $content
         );
     }


### PR DESCRIPTION
wegen Umstellung auf PHP 7.2 habe ich mehrere, ältere Webseiten mit Redaxo 4.x auf Redaxo 4.7.2 umgestellt. Bei einer Seite hatte ich plötzlich ein Problem, ich bekam einen Deprecated-Fehler bezüglich create_function() in der Datei class.rex_article_base.inc.php. Dieser Fix hat das Problem gelöst...